### PR TITLE
Update links to supported middleware topics

### DIFF
--- a/pages/en/lb3/Defining-middleware.md
+++ b/pages/en/lb3/Defining-middleware.md
@@ -19,8 +19,7 @@ Using phases helps to avoid ordering issues that can occur with standard Express
 LoopBack supports the following types of middleware:
 
 * **Pre-processing middleware** for custom application logic. See [example of pre-processing middleware](#pre-processing-middleware). 
-* **Dynamic request handling middleware** to serve dynamically-generated responses, for example HTML pages rendered from templates and JSON responses to REST API requests.
-  See [example pending].
+* **Dynamic request handling middleware** to serve dynamically-generated responses, for example HTML pages rendered from templates and JSON responses to REST API requests. See [example pending].
 * **Static middleware** to serve static client-side assets.  See [example of static middleware](#static-middleware).
 * **Error-handling middleware** to deal with request errors. See [example of error-handling middleware](#error-handling-middleware).
 


### PR DESCRIPTION
The the pre-processing link was incorrect (pointed at static),
but there also doesn't seem to be an accurate 'dynamic
request handling' example. I'll add one once I figure it out
in loopback if someone doesn't already.